### PR TITLE
Inject date checked so we know when the error happened

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -44,7 +44,7 @@ def get_version_information(deployment)
     deployment[:error] = "Didn't get JSON from API."
   end
 rescue => e
-  deployment.merge!(error: "#{e.class}: #{e.message}")
+  deployment.merge!(error: "#{e.class}: #{e.message}", date_checked: Date.today)
 end
 
 def main


### PR DESCRIPTION
Right now there are errors:

![image](https://user-images.githubusercontent.com/12306/31122555-d3daec58-a898-11e7-8f22-0e34d87b0810.png)

With no corresponding check date:

![image](https://user-images.githubusercontent.com/12306/31122565-dc2a4eee-a898-11e7-96b7-da45f7d807da.png)

This PR fixes that. 